### PR TITLE
[FE] 메인 페이지 API 응답 처리 및 에러 핸들링 개선

### DIFF
--- a/src/app/(main)/page.tsx
+++ b/src/app/(main)/page.tsx
@@ -1,21 +1,72 @@
 import Image from "next/image";
-import { Experience } from "@/types/admin/experience";
-
-async function getProfileSettings() {
-  const res = await fetch(
-    `${process.env.NEXT_PUBLIC_API_URL}/api/profile-settings`,
-    {
-      cache: "no-store",
-    },
-  );
-  return res.json();
-}
+import { Experience } from "@/types/api/experience";
 
 async function getExperiences(): Promise<Experience[]> {
-  const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/api/experience`, {
-    cache: "no-store",
-  });
-  return res.json();
+  try {
+    const res = await fetch(
+      `${process.env.NEXT_PUBLIC_API_URL}/api/experience`,
+      {
+        cache: "no-store",
+      },
+    );
+
+    if (!res.ok) {
+      throw new Error(`경력 정보를 불러오는데 실패했습니다: ${res.status}`);
+    }
+
+    const json = await res.json();
+
+    if (json.success && Array.isArray(json.data)) {
+      return json.data;
+    }
+
+    if (Array.isArray(json)) {
+      return json;
+    }
+
+    console.error("예상치 못한 API 응답 형식:", json);
+    return [];
+  } catch (error) {
+    console.error("경력 정보 조회 실패:", error);
+    return [];
+  }
+}
+
+async function getProfileSettings() {
+  try {
+    const res = await fetch(
+      `${process.env.NEXT_PUBLIC_API_URL}/api/profile-settings`,
+      {
+        cache: "no-store",
+      },
+    );
+
+    if (!res.ok) {
+      throw new Error(`프로필 정보를 불러오는데 실패했습니다: ${res.status}`);
+    }
+
+    const json = await res.json();
+
+    if (json.success && json.data) {
+      return json.data;
+    }
+
+    if (json && !json.success) {
+      return json;
+    }
+
+    console.error("예상치 못한 프로필 응답 형식:", json);
+    return {
+      main_title: "",
+      main_description: "",
+    };
+  } catch (error) {
+    console.error("프로필 정보 조회 실패:", error);
+    return {
+      main_title: "",
+      main_description: "",
+    };
+  }
 }
 
 function formatPeriod(start: string, end: string | null): string {


### PR DESCRIPTION
# 주요 변경 사항
### 문제:
메인 페이지에서 `experiences.map is not a function` 오류 발생
### 원인:
- API가 { success: true, data: [...] } 형식으로 응답하는데 배열을 직접 기대함
- 에러 처리 로직 부재
- HTTP 상태 코드 검증 없음
# 해결
### 1. API 응답 형식 처리
```typescript
// Before
async function getExperiences(): Promise {
  const res = await fetch(url);
  return res.json(); // XXX 그냥 반환
}

// After  
async function getExperiences(): Promise {
  const json = await res.json();
  
  // { success: true, data: [...] } 형식 처리
  if (json.success && Array.isArray(json.data)) {
    return json.data;
  }
  
  // 배열 직접 반환 (레거시 호환)
  if (Array.isArray(json)) {
    return json;
  }
  
  return []; // 안전한 기본값
}
```
### 2. 에러 핸들링 강화
- HTTP 상태 코드 검증 (`res.ok`)
- try-catch 블록으로 네트워크 오류 처리
- 에러 발생 시 빈 배열/기본값 반환 (크래시 방지)

### 3. 개발자 경험 개선
- 에러 메시지 한글화
- 콘솔 로깅으로 디버깅 용이성 향상

# 주요 파일 변경
- `src/app/(main)/page.tsx`
  - `getExperiences()` 함수 개선
  - `getProfileSettings()` 함수 개선

---
# 스크린샷
<img width="1902" height="928" alt="스크린샷 2026-01-22 오후 11 11 02" src="https://github.com/user-attachments/assets/a2a57c50-e718-474a-af9c-1bfcd967ac66" />
<img width="1905" height="926" alt="스크린샷 2026-01-22 오후 11 11 14" src="https://github.com/user-attachments/assets/ae04b954-adf7-43c0-8a20-153a7128039f" />
<img width="1904" height="928" alt="스크린샷 2026-01-22 오후 11 11 20" src="https://github.com/user-attachments/assets/ad5a1e22-7aae-47a9-a7ff-df9a1479003d" />


