### PR TITLE
Release: v1.8.0 - 모바일 UI 레이아웃 및 타이포그래피 일괄 정리

### DIFF
--- a/src/app/(main)/HomeClient.tsx
+++ b/src/app/(main)/HomeClient.tsx
@@ -22,11 +22,11 @@ export default function HomeClient({
 
   return (
     <PageLayout className="bg-white">
-      <section className="mx-auto w-full px-4 sm:px-6 lg:px-8">
+      <section className="mx-auto w-full sm:px-6 ">
         <h1 className="mb-4 whitespace-pre-line break-words text-left text-2xl font-bold sm:mb-6 sm:text-3xl md:text-right md:text-4xl">
           {profile?.main_title}
         </h1>
-        <p className="whitespace-pre-line break-words text-left text-base leading-relaxed sm:text-lg md:text-right">
+        <p className="whitespace-pre-line break-keep text-left text-base leading-relaxed sm:text-lg md:text-right">
           {profile?.main_description}
         </p>
       </section>
@@ -41,7 +41,7 @@ export default function HomeClient({
         />
       </div>
 
-      <section className="mx-auto w-full px-4 pb-20 sm:px-6 md:pb-24 lg:px-8 lg:pb-32">
+      <section className="mx-auto w-full pb-20 sm:px-6 md:pb-24 lg:pb-32">
         <div className="space-y-14 sm:space-y-16 md:space-y-20">
           {experiences.map((exp) => (
             <ExperienceCard key={exp.id} experience={exp} />

--- a/src/app/(main)/contact/page.tsx
+++ b/src/app/(main)/contact/page.tsx
@@ -23,7 +23,7 @@ export default function ContactPage() {
         <h1 className="mb-3 text-4xl font-bold leading-none sm:text-6xl md:text-[80px]">
           Contact me
         </h1>
-        <p className="text-base leading-relaxed text-gray-222 sm:text-lg">
+        <p className="text-base break-keep text-gray-222 sm:text-lg">
           남겨주신 메시지는 대시보드와 개인 이메일을 통해 실시간으로 확인하고
           있습니다.
         </p>

--- a/src/app/(main)/etc/page.tsx
+++ b/src/app/(main)/etc/page.tsx
@@ -18,7 +18,7 @@ export default function EtcPage() {
           <h1 className="mb-3 text-4xl font-bold leading-none sm:text-6xl md:text-[80px]">
             Etc
           </h1>
-          <p className="text-base leading-relaxed text-gray-222 sm:text-lg">
+          <p className="text-base break-keep text-gray-222 sm:text-lg">
             개발하면서 마주친 문제들, 배운 것들, 그리고 생각들을 기록합니다.
           </p>
         </div>

--- a/src/app/(main)/experience/ExperienceClient.tsx
+++ b/src/app/(main)/experience/ExperienceClient.tsx
@@ -75,11 +75,11 @@ export default function ExperienceClient({
         />
       </section>
 
-      <section className="max-w-7xl mx-auto px-4">
+      <section className="max-w-7xl mx-auto">
         {displayExperience && <ExperienceCard experience={displayExperience} />}
       </section>
 
-      <section className="max-w-7xl mx-auto px-4 mt-20">
+      <section className="max-w-7xl mx-auto mt-20">
         <ExperienceFilters
           experiences={experiences}
           years={availableYears}

--- a/src/app/admin/posts/page.tsx
+++ b/src/app/admin/posts/page.tsx
@@ -89,7 +89,7 @@ export default function PostsPage() {
       <AdminSummaryGrid items={summaryItems} columns={2} />
 
       <AdminActionBar>
-        <div className="flex w-full items-center justify-end gap-2">
+        <div className="grid w-full gap-2 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-center">
           <AdminSearchBar
             placeholder="게시글 검색"
             searchValue={searchQuery}
@@ -101,6 +101,7 @@ export default function PostsPage() {
             <DeleteButton
               onClick={openDeleteModal}
               disabled={selectedIds.length === 0}
+              className="w-full justify-center whitespace-nowrap sm:justify-self-end sm:w-auto"
             />
           )}
         </div>

--- a/src/components/admin/categories/CategoryGroup.tsx
+++ b/src/components/admin/categories/CategoryGroup.tsx
@@ -17,13 +17,13 @@ export function CategoryGroup({
   return (
     <div className="border rounded-lg overflow-hidden border-gray-ddd bg-white">
       {/* 1차 카테고리 헤더 */}
-      <div className="flex items-center justify-between p-5 bg-bg-light">
+      <div className="flex flex-col gap-3 bg-bg-light p-4 sm:flex-row sm:items-center sm:justify-between sm:p-5">
         {status.editingId === parent.id ? (
           // 수정 모드
-          <div className="flex gap-2 flex-1 mr-4">
+          <div className="flex w-full min-w-0 flex-col gap-2 sm:mr-4 sm:flex-1 sm:flex-row">
             <input
               autoFocus
-              className="flex-1 p-1 px-2 border rounded outline-none bg-white"
+              className="min-w-0 flex-1 rounded border bg-white p-1 px-2 outline-none"
               value={status.editName}
               onChange={(e) => setters.setEditName(e.target.value)}
               onKeyDown={(e) =>
@@ -35,7 +35,7 @@ export function CategoryGroup({
               size="sm"
               onClick={() => handlers.handleUpdate(parent.id)}
               disabled={!isMaster}
-              className={disabledStyles}
+              className={`whitespace-nowrap sm:w-auto ${disabledStyles}`}
             >
               저장
             </Button>
@@ -43,7 +43,7 @@ export function CategoryGroup({
               variant="secondary"
               size="sm"
               onClick={() => setters.setEditingId(null)}
-              className={disabledStyles}
+              className={`whitespace-nowrap sm:w-auto ${disabledStyles}`}
             >
               취소
             </Button>
@@ -57,13 +57,13 @@ export function CategoryGroup({
         )}
 
         {/* 1차 카테고리 액션 버튼 */}
-        <div className="flex gap-2">
+        <div className="grid w-full grid-cols-3 gap-2 sm:w-auto sm:flex">
           <Button
             variant="secondary"
             size="md"
             onClick={() => setters.setAddingParentId(parent.id)}
             disabled={!isMaster}
-            className={disabledStyles}
+            className={`w-full whitespace-nowrap sm:w-auto ${disabledStyles}`}
           >
             추가
           </Button>
@@ -72,7 +72,7 @@ export function CategoryGroup({
             size="md"
             onClick={() => handlers.openEdit(parent)}
             disabled={!isMaster}
-            className={disabledStyles}
+            className={`w-full whitespace-nowrap sm:w-auto ${disabledStyles}`}
           >
             수정
           </Button>
@@ -81,7 +81,7 @@ export function CategoryGroup({
             size="md"
             onClick={() => handlers.openDelete(parent.id)}
             disabled={!isMaster}
-            className={disabledStyles}
+            className={`w-full whitespace-nowrap sm:w-auto ${disabledStyles}`}
           >
             삭제
           </Button>
@@ -107,7 +107,7 @@ export function CategoryGroup({
 
         {/* 2차 추가 인라인 폼: 관리자이고 추가 모드일 때만 표시 */}
         {isMaster && status.addingParentId === parent.id && (
-          <div className="p-4 bg-gray-50 flex gap-2 border-t border-gray-eee">
+          <div className="flex flex-col gap-2 border-t border-gray-eee bg-gray-50 p-4 sm:flex-row">
             <input
               autoFocus
               placeholder="새 2차 카테고리 이름"
@@ -122,7 +122,7 @@ export function CategoryGroup({
               variant="secondary"
               size="sm"
               onClick={() => handlers.handleAddSub(parent.id)}
-              className="whitespace-nowrap"
+              className="w-full whitespace-nowrap sm:w-auto"
             >
               저장
             </Button>
@@ -130,7 +130,7 @@ export function CategoryGroup({
               variant="ghost"
               size="sm"
               onClick={() => setters.setAddingParentId(null)}
-              className="whitespace-nowrap"
+              className="w-full whitespace-nowrap sm:w-auto"
             >
               취소
             </Button>

--- a/src/components/admin/categories/CategoryItem.tsx
+++ b/src/components/admin/categories/CategoryItem.tsx
@@ -17,12 +17,12 @@ export function CategoryItem({
   const disabledStyles = !isMaster ? "opacity-50 cursor-not-allowed" : "";
 
   return (
-    <div className="flex items-center justify-between py-3 px-5 hover:bg-gray-50 transition-colors">
+    <div className="flex flex-col gap-2 px-4 py-3 transition-colors hover:bg-gray-50 sm:flex-row sm:items-center sm:justify-between sm:px-5">
       {isEditing ? (
-        <div className="flex gap-2 flex-1 mr-4 ml-6">
+        <div className="ml-0 flex w-full min-w-0 flex-col gap-2 sm:mr-4 sm:ml-6 sm:flex-1 sm:flex-row">
           <input
             autoFocus
-            className="flex-1 p-1 px-2 border rounded text-sm outline-none focus:border-gray-555 bg-white"
+            className="min-w-0 flex-1 rounded border bg-white p-1 px-2 text-sm outline-none focus:border-gray-555"
             value={editName}
             onChange={(e) => onEditChange(e.target.value)}
           />
@@ -30,16 +30,21 @@ export function CategoryItem({
             variant="primary"
             size="sm"
             onClick={() => onUpdate(category.id)}
-            className={disabledStyles}
+            className={`w-full whitespace-nowrap sm:w-auto ${disabledStyles}`}
           >
             저장
           </Button>
-          <Button variant="ghost" size="sm" onClick={onCancel}>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={onCancel}
+            className="w-full whitespace-nowrap sm:w-auto"
+          >
             취소
           </Button>
         </div>
       ) : (
-        <div className="flex items-center gap-2 text-gray-600 pl-4">
+        <div className="flex w-full items-center gap-2 pl-1 text-gray-600 sm:pl-4">
           <Icon type="fileBlank" size={16} />
           <span>
             {category.name}
@@ -49,12 +54,12 @@ export function CategoryItem({
           </span>
         </div>
       )}
-      <div className="flex gap-2">
+      <div className="grid w-full grid-cols-2 gap-2 sm:w-auto sm:flex">
         <Button
           variant="secondary"
           size="sm"
           onClick={() => onOpenEdit(category)}
-          className={disabledStyles}
+          className={`w-full whitespace-nowrap sm:w-auto ${disabledStyles}`}
         >
           수정
         </Button>
@@ -62,7 +67,7 @@ export function CategoryItem({
           variant="danger"
           size="sm"
           onClick={() => onOpenDelete(category.id)}
-          className={disabledStyles}
+          className={`w-full whitespace-nowrap sm:w-auto ${disabledStyles}`}
         >
           삭제
         </Button>

--- a/src/components/admin/common/AdminSearchBar.tsx
+++ b/src/components/admin/common/AdminSearchBar.tsx
@@ -10,8 +10,8 @@ export function AdminSearchBar({
   filterItems = [],
 }: AdminSearchBarProps) {
   return (
-    <div className="flex w-full flex-wrap justify-end gap-2">
-      <div className="relative w-full sm:w-[300px]">
+    <div className="flex w-full min-w-0 items-center justify-end gap-2">
+      <div className="relative min-w-0 flex-1 sm:w-[300px] sm:flex-none">
         <input
           type="text"
           value={searchValue}
@@ -30,7 +30,11 @@ export function AdminSearchBar({
       {filterItems.length > 0 && (
         <Dropdown
           trigger={
-            <Button variant="secondary" size="md" className="w-full sm:w-auto">
+            <Button
+              variant="secondary"
+              size="md"
+              className="shrink-0 whitespace-nowrap"
+            >
               필터 <Icon type="chevronDown" size={20} />
             </Button>
           }

--- a/src/components/admin/experience/ExperienceCard.tsx
+++ b/src/components/admin/experience/ExperienceCard.tsx
@@ -16,15 +16,15 @@ export function ExperienceCard({
   const isWork = experience.type === "WORK";
 
   return (
-    <div className="p-10 border border-gray-ddd rounded-xl relative hover:border-gray-400 transition-colors">
-      <div className="flex flex-col 2xl:flex-row gap-8">
+    <div className="p-6 border border-gray-ddd rounded-xl relative hover:border-gray-400 transition-colors sm:p-10">
+      <div className="flex flex-col 2xl:flex-row gap-4 2xl:gap-8">
         {/* 회사/주요 업무 */}
         <div className="w-full 2xl:max-w-[600px]">
-          <div className="text-2xl font-bold mb-2.5">
+          <div className="text-[18px] sm:text-2xl font-bold mb-2.5">
             <h2>{experience.company}</h2>
             <p>{experience.team}</p>
           </div>
-          <ul className="text-gray-555 text-lg">
+          <ul className="text-gray-555 text-[14px] sm:text-lg">
             {experience.description.map((desc, idx) => (
               <li key={idx}>{desc}</li>
             ))}
@@ -34,10 +34,10 @@ export function ExperienceCard({
         <div className="flex flex-col xl:flex-col 2xl:flex-row gap-8 flex-1">
           {/* 다닌 기간 */}
           <div className="flex-1">
-            <span className="font-medium text-lg block">
+            <span className="font-medium text-[14px] sm:text-lg block">
               {formatPeriod(experience.start_date, experience.end_date)}
             </span>
-            <span className="text-gray-999 text-base block mt-1">
+            <span className="text-gray-999 text-[14px] sm:text-base block mt-1">
               {calculateDuration(experience.start_date, experience.end_date)}
             </span>
             <Badge className="bg-bg-light py-2 px-2.5 text-base mt-5">

--- a/src/components/common/Button.tsx
+++ b/src/components/common/Button.tsx
@@ -11,7 +11,7 @@ export const Button = ({
   ...props
 }: ButtonProps) => {
   const baseStyles =
-    "inline-flex items-center justify-center rounded font-medium transition-colors gap-1.5 cursor-pointer";
+    "inline-flex items-center justify-center rounded font-medium transition-colors gap-1.5 cursor-pointer text-[14px] sm:text-base";
 
   const variants = {
     primary: "bg-black text-white hover:bg-gray-800",
@@ -21,9 +21,9 @@ export const Button = ({
   };
 
   const sizes = {
-    sm: "px-3 py-1.5 text-xs",
-    md: "px-3 py-1.5 text-base",
-    lg: "px-6 py-3 text-base",
+    sm: "px-3 py-1.5",
+    md: "px-3 py-1.5",
+    lg: "px-6 py-3",
   };
 
   const iconSize = size === "sm" ? 16 : 20;

--- a/src/components/domains/experience/ExperienceCard.tsx
+++ b/src/components/domains/experience/ExperienceCard.tsx
@@ -33,7 +33,10 @@ export function ExperienceCard({ experience }: { experience: Experience }) {
         {/* 업무 설명 */}
         <div className="mt-6 mb-5 text-left md:mt-13 md:mb-7 md:text-right">
           {experience.description.map((desc, idx) => (
-            <p key={idx} className="text-base leading-relaxed sm:text-lg">
+            <p
+              key={idx}
+              className="text-base leading-relaxed sm:text-lg break-keep"
+            >
               {desc}
             </p>
           ))}

--- a/src/features/admin/posts/ui/PostCategorySelect.tsx
+++ b/src/features/admin/posts/ui/PostCategorySelect.tsx
@@ -17,9 +17,9 @@ export function PostCategorySelect({
   subCategories,
 }: PostCategorySelectProps) {
   return (
-    <div className="flex gap-4">
+    <div className="grid gap-4 md:grid-cols-2">
       <div className="flex-1">
-        <label className="text-base font-medium mb-4 inline-block">
+        <label className="inline-block text-base font-medium mb-4">
           1차 카테고리
         </label>
         <Select
@@ -29,7 +29,7 @@ export function PostCategorySelect({
             setCategory2("");
           }}
         >
-          <SelectTrigger className="w-full px-6 py-5.5 border border-black rounded-none">
+          <SelectTrigger className="flex w-full items-center justify-between rounded-none border border-black px-6 py-5.5 text-base">
             <SelectValue placeholder="1차 카테고리 선택" />
             <Icon type="solidDownArrowAlt" size={12} className="text-black" />
           </SelectTrigger>
@@ -44,7 +44,7 @@ export function PostCategorySelect({
       </div>
 
       <div className="flex-1">
-        <label className="text-base font-medium mb-4 inline-block">
+        <label className="inline-block text-base font-medium mb-4">
           2차 카테고리
         </label>
         <Select
@@ -52,7 +52,7 @@ export function PostCategorySelect({
           onValueChange={setCategory2}
           disabled={!category1 || subCategories.length === 0}
         >
-          <SelectTrigger className="w-full px-6 py-5.5 border border-black rounded-none">
+          <SelectTrigger className="flex w-full items-center justify-between rounded-none border border-black px-6 py-5.5 text-base">
             <SelectValue
               placeholder={
                 !category1

--- a/src/features/admin/profile/ui/ProfileContactSection.tsx
+++ b/src/features/admin/profile/ui/ProfileContactSection.tsx
@@ -7,6 +7,13 @@ interface ProfileContactSectionProps {
   onChange: (key: keyof ProfileFormData, value: string) => void;
 }
 
+type ContactKey = "phone" | "email";
+
+const contactFields: { key: ContactKey; label: string }[] = [
+  { key: "phone", label: "전화번호" },
+  { key: "email", label: "이메일" },
+];
+
 export function ProfileContactSection({
   data,
   onChange,
@@ -18,23 +25,18 @@ export function ProfileContactSection({
       <h3 className="text-lg font-bold pb-5 border-b border-gray-ddd">
         연락처 정보
       </h3>
-      <div className="grid grid-cols-2 gap-4">
-        <div className="flex flex-col gap-4">
-          <label className="text-base font-medium">전화번호</label>
-          <Input
-            value={data.phone}
-            onChange={(e) => onChange("phone", e.target.value)}
-            disabled={!isMaster}
-          />
-        </div>
-        <div className="flex flex-col gap-4">
-          <label className="text-base font-medium">이메일</label>
-          <Input
-            value={data.email}
-            onChange={(e) => onChange("email", e.target.value)}
-            disabled={!isMaster}
-          />
-        </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        {contactFields.map(({ key, label }) => (
+          <div key={key} className="flex flex-col gap-4">
+            <label className="text-base font-medium">{label}</label>
+            <Input
+              value={data[key]}
+              onChange={(e) => onChange(key, e.target.value)}
+              disabled={!isMaster}
+            />
+          </div>
+        ))}
       </div>
     </section>
   );

--- a/src/features/admin/profile/ui/ProfileLinkSection.tsx
+++ b/src/features/admin/profile/ui/ProfileLinkSection.tsx
@@ -7,6 +7,14 @@ interface ProfileLinkSectionProps {
   onChange: (key: keyof ProfileFormData, value: string) => void;
 }
 
+type LinkKey = "resume_url" | "pdf_url" | "github_url";
+
+const linkFields: { key: LinkKey; label: string }[] = [
+  { key: "resume_url", label: "이력서" },
+  { key: "pdf_url", label: "포트폴리오 PDF" },
+  { key: "github_url", label: "깃허브" },
+];
+
 export function ProfileLinkSection({
   data,
   onChange,
@@ -18,34 +26,18 @@ export function ProfileLinkSection({
       <h3 className="text-lg font-bold pb-5 border-b border-gray-ddd">
         링크 연결
       </h3>
-      <div className="grid grid-cols-3 gap-4">
-        <div className="flex flex-col gap-2">
-          <label className="text-base font-medium">이력서</label>
-          <Input
-            placeholder="URL을 입력하세요."
-            value={data.resume_url}
-            onChange={(e) => onChange("resume_url", e.target.value)}
-            disabled={!isMaster}
-          />
-        </div>
-        <div className="flex flex-col gap-2">
-          <label className="text-base font-medium">포트폴리오 PDF</label>
-          <Input
-            placeholder="URL을 입력하세요."
-            value={data.pdf_url}
-            onChange={(e) => onChange("pdf_url", e.target.value)}
-            disabled={!isMaster}
-          />
-        </div>
-        <div className="flex flex-col gap-2">
-          <label className="text-base font-medium">깃허브</label>
-          <Input
-            placeholder="URL을 입력하세요."
-            value={data.github_url}
-            onChange={(e) => onChange("github_url", e.target.value)}
-            disabled={!isMaster}
-          />
-        </div>
+      <div className="flex flex-wrap gap-4">
+        {linkFields.map(({ key, label }) => (
+          <div className="flex flex-col gap-4 flex-1 min-w-[200px]">
+            <label className="text-base font-medium">{label}</label>
+            <Input
+              placeholder="URL을 입력하세요."
+              value={data[key]}
+              onChange={(e) => onChange(key, e.target.value)}
+              disabled={!isMaster}
+            />
+          </div>
+        ))}
       </div>
     </section>
   );


### PR DESCRIPTION
### 🎯 주요 변경 사항

- `admin/posts` 액션바(검색/필터/삭제 버튼) 모바일 정렬 구조 조정
- `admin/categories` 및 `admin/profile` 관련 UI 컴포넌트 배치 정리
- `experience` 카드(관리자/도메인) 및 메인 `experience` 화면 모바일 타이포/간격 조정
- 공통 `Button` 컴포넌트 모바일 폰트 크기 기준 통일
- `posts/editor` 카테고리 셀렉트 트리거 스타일 정렬

---

### 📝 상세 설명

이번 릴리즈는 모바일 해상도에서 깨지거나 과하게 커 보이던 UI를 일괄 정리한 릴리즈입니다.
관리자 영역(`posts`, `categories`, `profile`, `experience`)과 메인 영역(`Home`, `contact`, 
`etc`, `experience`)에 걸쳐 레이아웃/타이포 일관성을 맞췄습니다.

---

### 🔍 변경 이유

- 모바일에서 액션바 요소 줄바꿈/겹침으로 조작성이 떨어지는 문제 해결
- 카드/버튼/셀렉트의 폰트 크기와 간격 불일치 해소
- 관리자 페이지와 메인 페이지 간 UI 밀도 차이를 줄여 사용성 일관성 확보

---

### ✅ 테스트 방법

1. 모바일 뷰포트에서 `admin/*` 액션바 정렬, 버튼/입력 배치 확인
2. `admin/experience`와 `(main)/experience`에서 카드 텍스트 크기 및 간격 확인
3. 공통 `Button` 모바일 뷰포트에서 폰트 크기 변화 확인

---

### 📌 참고 사항

- 공통 Button 컴포넌트 변경으로 전체 어드민 페이지에 영향이 있습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Style**
  * 다양한 화면 크기에 대한 반응형 디자인 개선: 패딩, 간격, 텍스트 크기 조정
  * 모바일 및 데스크톱에서 최적화된 버튼 및 폼 레이아웃
  * 텍스트 줄 바꿈 동작 개선으로 더 나은 가독성
  * 카테고리, 경험 카드 등의 시각적 스타일 업데이트

* **Refactor**
  * 프로필 섹션 렌더링 로직 최적화 및 확장성 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->