### PR TITLE
[FE] highlight.js 정규식 오류로 인한 etc 페이지 에러 수정 및 backlog 페이지 모바일 UI 개선

### DIFF
--- a/src/app/(main)/backlog/BacklogClient.tsx
+++ b/src/app/(main)/backlog/BacklogClient.tsx
@@ -52,25 +52,27 @@ export default function BacklogClient({
   );
 
   return (
-    <div className="mt-8 w-full overflow-x-auto">
-      <div className="min-w-[1200px] [&_table]:table-auto">
-        <AdminTable<Backlog>
-          columns={columns}
-          data={pagedData}
-          selectedIds={[]}
-          getItemId={(item) => String(item.id)}
-          showAddColumn={false}
-          onToggleSelect={() => {}}
-          onToggleSelectAll={() => {}}
-        />
-
-        <div className="mt-6 flex justify-center">
-          <CommonPagination
-            currentPage={currentPage}
-            totalPages={totalPages}
-            onPageChange={(page) => setCurrentPage(page)}
+    <div className="mt-8 w-full">
+      <div className="w-full overflow-x-auto">
+        <div className="min-w-[1200px] [&_table]:table-auto">
+          <AdminTable<Backlog>
+            columns={columns}
+            data={pagedData}
+            selectedIds={[]}
+            getItemId={(item) => String(item.id)}
+            showAddColumn={false}
+            onToggleSelect={() => {}}
+            onToggleSelectAll={() => {}}
           />
         </div>
+      </div>
+
+      <div className="mt-6 flex justify-center">
+        <CommonPagination
+          currentPage={currentPage}
+          totalPages={totalPages}
+          onPageChange={(page) => setCurrentPage(page)}
+        />
       </div>
     </div>
   );

--- a/src/app/(main)/backlog/page.tsx
+++ b/src/app/(main)/backlog/page.tsx
@@ -11,9 +11,11 @@ export default async function BacklogMainPage() {
 
   return (
     <PageLayout>
-      <header className="mb-25">
-        <h1 className="text-[80px] font-bold leading-none mb-3">Backlog</h1>
-        <p className="text-lg text-gray-222 leading-relaxed">
+      <header className="mb-14 sm:mb-20 md:mb-25">
+        <h1 className="mb-3 text-4xl font-bold leading-none sm:text-6xl md:text-[80px]">
+          Backlog
+        </h1>
+        <p className="text-base break-keep text-gray-222 sm:text-lg">
           본 포트폴리오의 백로그를 나타내는 페이지입니다.
         </p>
       </header>

--- a/src/app/(main)/etc/EtcClient.tsx
+++ b/src/app/(main)/etc/EtcClient.tsx
@@ -1,9 +1,8 @@
 "use client";
 
 import Link from "next/link";
-import hljs from "highlight.js";
 import DeleteModal from "@/components/common/DeleteModal";
-import { useCallback, useEffect, useRef } from "react";
+import { useCallback } from "react";
 import { useCategories } from "@/hooks/categories/useCategories";
 import { Icon } from "@/components/common/Icon";
 import { CategoryResponse } from "@/types/api/category";
@@ -19,8 +18,6 @@ export default function EtcClient({
 }: {
   initialCategories: CategoryResponse;
 }) {
-  const contentRootRef = useRef<HTMLDivElement>(null);
-
   const { categories } = useCategories({
     initialData: initialCategories,
   });
@@ -46,22 +43,8 @@ export default function EtcClient({
 
   const pagination = useEtcFilter(posts, 1);
 
-  useEffect(() => {
-    const root = contentRootRef.current;
-    if (!root) return;
-
-    const blocks = root.querySelectorAll("pre code");
-    blocks.forEach((block) => {
-      if (!(block instanceof HTMLElement)) return;
-      hljs.highlightElement(block);
-    });
-  }, [pagination.paginatedPosts]);
-
   return (
-    <div
-      ref={contentRootRef}
-      className="flex w-full flex-col items-start gap-8 lg:flex-row lg:gap-10"
-    >
+    <div className="flex w-full flex-col items-start gap-8 lg:flex-row lg:gap-10">
       <aside className="w-full lg:w-64 lg:shrink-0 lg:sticky lg:top-10">
         <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-1">
           {categories.map((parent) => (

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -2,6 +2,15 @@ import MarkdownIt from "markdown-it";
 // import markdownItHighlightjs from "markdown-it-highlightjs";
 import hljs from "highlight.js";
 
+function escapeHtml(value: string) {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
 function markdownItIns(md: MarkdownIt) {
   md.inline.ruler.before("emphasis", "ins", (state, silent) => {
     const start = state.pos;
@@ -48,11 +57,18 @@ export const mdParser = new MarkdownIt({
   typographer: true,
   highlight: (code, lang) => {
     const validLang = hljs.getLanguage(lang || "") ? lang : "plaintext";
-    const highlighted = validLang
-      ? hljs.highlight(code, { language: validLang }).value
-      : code;
 
-    return `<pre data-lang="${validLang}" class="code-block"><code class="hljs">${highlighted}</code></pre>`;
+    try {
+      const highlighted = hljs.highlight(code, {
+        language: validLang,
+        ignoreIllegals: true,
+      }).value;
+
+      return `<pre data-lang="${validLang}" class="code-block"><code class="hljs">${highlighted}</code></pre>`;
+    } catch {
+      const escaped = escapeHtml(code);
+      return `<pre data-lang="plaintext" class="code-block"><code class="hljs">${escaped}</code></pre>`;
+    }
   },
 }).use(markdownItIns);
 // .use(markdownItHighlightjs, {


### PR DESCRIPTION

### 🎯 주요 변경 사항

- `backlog` 페이지
    - `(main)/backlog` 타이틀/설명 스타일을 `(main)/contact`와 동일한 모바일 반응형 규칙으로 통일
    - `backlog` 테이블의 `overflow-x` 영역과 페이지네이션 영역 분리
    - 페이지네이션이 가로 스크롤에 같이 들어가지 않도록 구조 조정
- `etc` 페이지
    - `EtcClient`에서 클라이언트 사이드 `highlight.js` 실행 로직 제거
    - 마크다운 하이라이팅 실패 시 예외가 전파되지 않도록 `try/catch` 처리
    - 하이라이팅 실패 시 `plaintext` + HTML escape 폴백 추가

---

### 📝 상세 설명

`/etc` 페이지 접속 시 브라우저 콘솔에서 `Invalid regular expression` 예외가 발생하며
`Application error: a client-side exception has occurred`로 페이지가 깨지는 문제가 있었습니다.

원인 경로인 클라이언트 측 `highlight.js` 실행을 제거하고,
`src/lib/markdown.ts`의 `hljs.highlight(...)`에 방어 로직을 추가해
특정 언어/패턴에서 하이라이터가 실패해도 페이지 렌더가 중단되지 않도록 수정했습니다.

---

### 🔍 변경 이유

- 코드 블록 하이라이팅 중 라이브러리 내부 정규식 생성 실패가 발생할 수 있으며,
기존에는 해당 예외가 그대로 전파되어 `/etc` 페이지 전체가 크래시
- 사용자에게 페이지가 정상 노출되도록 예외 안전성 확보
- 모바일에서 backlog 타이틀 비율이 다른 메인 페이지와 불일치
- 테이블 가로 스크롤 시 페이지네이션까지 함께 이동해 사용성 저하

---

### ✅ 테스트 방법

1. 모바일 뷰에서 `backlog` 페이지 진입 후 타이틀 크기/간격이 `(main)/contact`와 동일 패턴인지 확인
2. `backlog` 페이지에서 테이블을 좌우 스크롤해도 페이지네이션이 고정되어 보이는지 확인

---

### 📌 참고 사항

- 빌드 이후 운영 `etc` 페이지 접속 시 클라이언트 예외가 발생하지 않는지 확인이 필요합니다.

---

### 📸 스크린샷 (선택)

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **UI 개선**
  * 백로그 페이지 헤더의 반응형 디자인 최적화로 다양한 화면 크기에서 개선된 레이아웃 제공

* **버그 수정**
  * 코드 블록 렌더링 안정성 강화 및 하이라이팅 실패 시 우아한 폴백 처리 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->